### PR TITLE
Clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,40 +4,44 @@ A Clojure project to build [Robocode](https://robocode.sourceforge.io/) robots.
 
 ## Prerequisites
 
-You must have a working installation of Clojure, Leiningen, and Robocode to for
-this project to properly work.  Setup steps for these can be found at their
+You must have a working installation of Clojure, Leiningen, and Robocode for
+this project to properly work. Setup steps for these can be found at their
 respective sites:
 
 * [Getting Started with Clojure](https://clojure.org/guides/getting_started)
 * [Install Leiningen](https://leiningen.org/#install)
-* [Install Robocode](https://robocode.sourceforge.io/)
+* [Install Robocode](https://robowiki.net/wiki/Robocode/Download_And_Install)
 
 Note: This project assumes that Robocode is installed into its default
 location which is `~/robocode`
 
 ## Setup & Test
 
-This project uses a makefile to simplify the installation and setup of
-your Robot.  Assuming that Robocode is installed in the default location of
-`~/robocode`, you can run:
+This project uses a makefile to simplify the installation and setup of your
+Robot.
+
+Assuming that Robocode is installed in the default location of
+`~/robocode`, from the directory where you have installed `robocode-clojure` you
+can run:
 
 ```
 make setup
 ```
 
-This will install a customer shell script called `cl-robocode.sh` into your
-`~/robocode` directory.  To run Robocode with a Clojure Robot, you must run
-Robocode from the command line using this script.
+This will install a custom shell script called `cl-robocode.sh` into your
+`~/robocode` directory. Later, you will use this script to run Robocode with a Clojure Robot.
 
-Then run:
+Next, run:
 
 ```
 make install
 ```
 
 This should compile the `DemoRobot` and install it into your `~/robocode/robots/`
-directory.  You can then verify everything is working by running Robocode.
-From the `~/robocode/` directory, run:
+directory.
+
+Now, you can verify everything is working by running Robocode. From the
+`~/robocode/` directory, run:
 
 ```
 ./cl-robocode.sh


### PR DESCRIPTION
This commit clarifies the README by:
  * Adding a link to the Download and Install page of the Robocode Wiki
    in the section on how to install prerequisites.
  * Noting that the initial commands in the Setup must be run from the
    directory where `robocode-clojure` is installed.
  * Clarifying that the `cl-robocode.sh` script is not run until after
    `make install` has been executed.
  * Fixing typos.